### PR TITLE
Upgrade Node to v6.10.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ADD views /var/derby-site/views
 
 # npm install all the things
 WORKDIR /var/derby-site
-RUN npm install
+RUN npm_config_spin=false npm_config_loglevel=warn npm install --production
 
 # expose any ports we need
 EXPOSE 4000

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # RUN-USING: docker run -p 4000:4000 --name derby-site --rm derbyjs/derby-site
 
 # specify base docker image
-FROM dockerfile/nodejs
+FROM node:6.10.3
 
 # copy over dependencies
 WORKDIR /var

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "derby": "0.6.0-alpha47",
+    "d-codemirror": "^0.2.5",
+    "derby": "^0.9.7",
     "derby-stylus": "^0.1",
     "express": "^4.12",
-    "serve-favicon": "^2.2",
+    "highlight.js": "^9.11.0",
     "marked": "^0.3",
-    "highlight.js": "^8.5",
-    "d-codemirror": "^0.2.5"
+    "serve-favicon": "^2.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Changes:
* Upgrade Dockerfile to use the node v6.10.3 docker image (the current image being used is very old).
* Reduce the npm logging to `warn` and only install production modules when building the docker image
* Upgrade derby to v0.9.7 from v0.6.0
* Upgrade highlight.js to latest version v9.11
* Re-order package dependencies alphabetically

I ran the site with the updates locally and the site seems to run fine on the newer versions.