### PR TITLE
Fix Support for Swarm Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,20 @@ To run the entire stack locally, you can use `docker-compose`. To do this,
 simply run:
 
 ```shell
-SWARM_MODE=false docker-compose up
+npm run compose-up
 ```
 
-from the `./deploy` directory. To change the underlying versions of `derby-site`
-or `derby-examples`, simply adjust the tags for the `image`.
+Similarly, `npm run compose-stop` will stop all containers and
+`npm run compose-down` will stop and remove all containers and networks created.
+
+You can also use Docker Compose directly by running the following command:
+
+```shell
+SWARM_MODE=false docker-compose -f ./deploy/docker-compose.yaml up
+```
+
+To change the underlying versions of `derby-site` or `derby-examples`, simply
+adjust the tags for the `image`.
 
 Production
 ----------
@@ -39,6 +48,13 @@ simply run `docker swarm init`. If you are prompted to include the
 `--advertise-addr` parameter, make sure this matches the instances **local** IP
 address, **not** the public address. Once you have done this, you can run the
 following command to create the stack from the `./deploy` directory:
+
+```shell
+npm run deploy
+```
+
+Alternatively, you can run this directly using the Docker CLI with the following
+command:
 
 ```shell
 SWARM_MODE=true docker stack deploy --compose-file docker-compose.yaml derbyjs

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Installation
 
 Clone this repository and install the dependencies:
 
-```
+```shell
 npm install
 ```
 
@@ -16,14 +16,19 @@ Development
 
 To run the site locally:
 
-```
+```shell
 npm start
 ```
 
 To run the entire stack locally, you can use `docker-compose`. To do this,
-simply run `docker-compose up` from the `./deploy` directory. To change the
-underlying versions of `derby-site` or `derby-examples`, simply adjust the tags
-for the `image`.
+simply run:
+
+```shell
+SWARM_MODE=false docker-compose up
+```
+
+from the `./deploy` directory. To change the underlying versions of `derby-site`
+or `derby-examples`, simply adjust the tags for the `image`.
 
 Production
 ----------
@@ -36,7 +41,7 @@ address, **not** the public address. Once you have done this, you can run the
 following command to create the stack from the `./deploy` directory:
 
 ```shell
-docker stack deploy --compose-file docker-compose.yaml derbyjs
+SWARM_MODE=true docker stack deploy --compose-file docker-compose.yaml derbyjs
 ```
 
 This will create all necessary resources. If you are making changes to the

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -22,12 +22,15 @@ services:
       update_config:
         parallelism: 1
         delay: 10s
+      labels: &derby_site_labels
+        traefik.enable: "true"
+        traefik.docker.network: derbyjs_derbyjs_overlay
+        traefik.frontend.rule: PathPrefix:/
+        traefik.port: "4000"
+        traefik.priority: "100"
     ports:
       - "4000:4000"
-    labels:
-      traefik.enable: "true"
-      traefik.frontend.rule: PathPrefix:/
-      traefik.priority: 100
+    labels: *derby_site_labels
     networks:
       - derbyjs_overlay
 
@@ -38,6 +41,27 @@ services:
       update_config:
         parallelism: 1
         delay: 10s
+      labels: &derby_examples_labels
+        traefik.enable: "true"
+        traefik.docker.network: derbyjs_derbyjs_overlay
+        traefik.charts.frontend.rule: Host:charts.derbyjs.com
+        traefik.charts.port: "8001"
+        traefik.chat.frontend.rule: Host:chat.derbyjs.com
+        traefik.chat.port: "8002"
+        traefik.codemirror.frontend.rule: Host:codemirror.derbyjs.com
+        traefik.codemirror.port: "8003"
+        traefik.directory.frontend.rule: Host:directory.derbyjs.com
+        traefik.directory.port: "8004"
+        traefik.hello.frontend.rule: Host:hello.derbyjs.com
+        traefik.hello.port: "8005"
+        traefik.sink.frontend.rule: Host:sink.derbyjs.com
+        traefik.sink.port: "8006"
+        traefik.todos.frontend.rule: Host:todos.derbyjs.com
+        traefik.todos.port: "8007"
+        traefik.widgets.frontend.rule: Host:widgets.derbyjs.com
+        traefik.widgets.port: "8008"
+        traefik.render.frontend.rule: Host:render.derbyjs.com
+        traefik.render.port: "8009"
     ports:
       - "8001:8001"
       - "8002:8002"
@@ -51,26 +75,7 @@ services:
     environment:
       MONGO_HOST: mongo
       REDIS_HOST: redis
-    labels:
-      traefik.enable: "true"
-      traefik.charts.frontend.rule: Host:charts.derbyjs.com
-      traefik.charts.port: 8001
-      traefik.chat.frontend.rule: Host:chat.derbyjs.com
-      traefik.chat.port: 8002
-      traefik.codemirror.frontend.rule: Host:codemirror.derbyjs.com
-      traefik.codemirror.port: 8003
-      traefik.directory.frontend.rule: Host:directory.derbyjs.com
-      traefik.directory.port: 8004
-      traefik.hello.frontend.rule: Host:hello.derbyjs.com
-      traefik.hello.port: 8005
-      traefik.sink.frontend.rule: Host:sink.derbyjs.com
-      traefik.sink.port: 8006
-      traefik.todos.frontend.rule: Host:todos.derbyjs.com
-      traefik.todos.port: 8007
-      traefik.widgets.frontend.rule: Host:widgets.derbyjs.com
-      traefik.widgets.port: 8008
-      traefik.render.frontend.rule: Host:render.derbyjs.com
-      traefik.render.port: 8009
+    labels: *derby_examples_labels
     networks:
       - derbyjs_overlay
 
@@ -91,6 +96,7 @@ services:
       - --ping.entrypoint=http
       - --docker
       - --docker.exposedbydefault=false
+      - --docker.swarmmode=${SWARM_MODE}
     networks:
       - derbyjs_overlay
 

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -72,6 +72,9 @@ services:
       - "8007:8007"
       - "8008:8008"
       - "8009:8009"
+    depends_on:
+      - mongo
+      - redis
     environment:
       MONGO_HOST: mongo
       REDIS_HOST: redis

--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "main": "index.js",
   "scripts": {
     "start": "node server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "compose-up": "SWARM_MODE=false docker-compose -f ./deploy/docker-compose.yaml up -d && exit 0",
+    "compose-stop": "SWARM_MODE=false docker-compose -f ./deploy/docker-compose.yaml stop && exit 0",
+    "compose-down": "SWARM_MODE=false docker-compose -f ./deploy/docker-compose.yaml down && exit 0",
+    "deploy": "SWARM_MODE=true docker stack deploy --compose-file ./deploy/docker-compose.yaml derbyjs && exit 0"
   },
   "dependencies": {
     "derby": "^0.10.0",


### PR DESCRIPTION
Turns out, Traefik has special conditions for discovery in Swarm Mode, and that's not entirely compatible with Compose Mode. This change addresses that.

* Adds `npm run` commands for `compose-up`, `compose-stop`, `compose-down`, and `deploy` along with supporting documentation.
* Modifies `docker-compose.yaml` to use an environment variable for `SWARM_MODE`.
* Attaches labels necessary for Traefik to work in Swarm and Compose mode using YAML anchors.