### PR TITLE
Update docs on captures event callback argument

### DIFF
--- a/md/docs/derby-0.10/models/events.md
+++ b/md/docs/derby-0.10/models/events.md
@@ -16,35 +16,35 @@ Racer emits events whenever it mutates data via `model.set()`, `model.push()`, e
 
 The event callback receives a number of arguments based on the path pattern and method. The arguments are:
 
-> `eventCallback(captures..., [event], args..., passed)`
-> * `captures` The path segment or segments that match the wildcards in the path pattern
-> * `event` The `'all'` event adds the emitted event name after the captures and before the args
+> `eventCallback([captures...], [event], args..., passed)`
+> * `captures` The path segment or segments that is passed in only when matching wildcards in the path pattern
+> * `event` Only the `'all'` event adds the emitted event name after the captures and before the args
 > * `args` Event specific arguments. See below
 > * `passed` An object with properties provided via `model.pass()`. See description below
 
 ### Event arguments
 
-> `changeEvent(captures..., value, previous, passed)`
+> `changeEvent([captures...], value, previous, passed)`
 > * `value` The current value at the path that was changed. Will be `undefined` for objects that were deleted
 > * `previous` The previous value at the path. Will be `undefined` for paths set for the first time
 
-> `insertEvent(captures..., index, values, passed)`
+> `insertEvent([captures...], index, values, passed)`
 > * `index` The index at which items were inserted
 > * `values` An array of values that were inserted. Always an array, even if only one item was pushed, unshifted, or inserted
 
-> `removeEvent(captures..., index, removed, passed)`
+> `removeEvent([captures...], index, removed, passed)`
 > * `value` The current value at the path that was changed. Will be `undefined` for objects that were deleted
 > * `removed` An array of values that were removed. Always an array, even if only one item was popped, shifted, or removed
 
-> `moveEvent(captures..., from, to, howMany, passed)`
+> `moveEvent([captures...], from, to, howMany, passed)`
 > * `from` The index from which items were moved
 > * `to` The index to which items were moved
 > * `howMany` How many items were moved
 
-> `loadEvent(captures..., document, passed)`
+> `loadEvent([captures...], document, passed)`
 > * `document` This event fires when a document is loaded via a subscription or fetch. It emits the value of the newly loaded document object
 
-> `unloadEvent(captures..., previousDocument, passed)`
+> `unloadEvent([captures...], previousDocument, passed)`
 > * `previousDocument` This event fires when a document is removed from the model via unsubscribe or unfetch. It emits the value of the document object that was unloaded
 
 On a string insert or string remove mutation, a `'change`' event is emitted, since strings are immutable values, and inserting or removing from a string requires changing its entire value. However, detail on what specifically was inserted or removed is neccessary to implement view bindings properly for realtime collaborative text editing. This additional information is added to the `passed` object. On a string insert, the passed object has an additional property of `$stringInsert: {index: Number, text: String}`. On a string remove, the passed object has an additional property of `$stringRemove: {index: Number, howMany: Number}`.
@@ -60,7 +60,7 @@ model.on('change', 'todos.*.completed', function(todoId, isComplete) {
   ...
 });
 
-// Matches all events
+// Matches all events - `path` and `event` are passed in to the event callback
 model.on('all', '**', function(path, event, args...) {
   ...
 });


### PR DESCRIPTION
Make it clear that the `captures` and `event` args will not always be passed in to the event callback.