### PR TITLE
Add line breaks to methods in doc

### DIFF
--- a/md/docs/derby-0.10/apps/routes.md
+++ b/md/docs/derby-0.10/apps/routes.md
@@ -3,8 +3,11 @@
 Routes map URL patterns to actions. Derby routes are powered by [Express](https://expressjs.com/). Within apps, routes are defined via the `get`, `post`, `put`, and `del` methods of the app created by `derby.createApp()`.
 
 > `app.get ( routePattern, callback(page, model, params, next) )`
+>
 > `app.post ( routePattern, callback(page, model, params, next) )`
+>
 > `app.put ( routePattern, callback(page, model, params, next) )`
+>
 > `app.del ( routePattern, callback(page, model, params, next) )`
 >
 > * `pattern`: A string containing a literal URL, an Express route pattern, or a regular expression. See [Express's routing documentation](https://expressjs.com/guide/routing.html) for more info.
@@ -59,6 +62,7 @@ For the most part, updating the URL client-side should be done with normal HTML 
 To update the URL after an action other than clicking a link, scripts can call methods on `app.history`. For example, an app might update the URL as the user scrolls and the page loads more content from a paginated list.
 
 > `app.history.push ( url, [render], [state], [e] )`
+>
 > `app.history.replace ( url, [render], [state], [e] )`
 >
 > * `url`: New URL to set for the current window


### PR DESCRIPTION
Align the methods to improve readability.

Before:

![screen shot 2019-02-04 at 10 10 49 am](https://user-images.githubusercontent.com/3713384/52228655-c007f400-2867-11e9-8d7a-f325e582cff8.png)

After:
![screen shot 2019-02-04 at 10 10 55 am](https://user-images.githubusercontent.com/3713384/52228670-c9915c00-2867-11e9-9620-4268ed6cbb28.png)
