### PR TITLE
Link to new GH Pages doc site, deprecate docs in this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ derby-site
 =============
 The [derbyjs.com](//derbyjs.com/) site, built with Derby.
 
+The docs in this repo are deprecated. Up-to-date docs are now maintained in the [main derby repo's docs directory](https://github.com/derbyjs/derby/tree/master/docs) and are automatically deployed to GitHub Pages at [derbyjs.github.io/derby/](https://derbyjs.github.io/derby/).
+
 Installation
 ------------
 

--- a/md/resources.md
+++ b/md/resources.md
@@ -1,30 +1,7 @@
 ## Community
 
-[Google Groups](https://groups.google.com/group/derbyjs)
-Mailing list
-
-[Gitter Chat](https://gitter.im/derbyjs/derby)
-GitHub chat for derby community
-
-[Stackoverflow DerbyJS tag](https://stackoverflow.com/questions/tagged/derbyjs)
-Best place for questions
-
-[Stackoverflow Chat (Ru)](https://chat.stackoverflow.com/rooms/41934/derbyjs-ru)
-Бла бла бла
-
 [Github Issues](https://github.com/derbyjs/derby/issues)
 Submit a problem
-
-[Lever YouTube](https://www.youtube.com/user/LeverApp)
-Lever uses derby in production and puts out some tutorial and meetup videos about Derby and ShareJS
-
-[Twitter](https://twitter.com/derbyjs)
-
-IRC
-derbyjs on [freenode.net](https://freenode.net)
-
-[Habrahabr.ru](https://habrahabr.ru/hub/derbyjs/)
-Habr Derby Hub
 
 
 ### Modules
@@ -88,8 +65,6 @@ This site
 
 Derby components from [ile](https://github.com/ile/)
 
-https://d-passport.herokuapp.com/
-[d-passport](https://github.com/ile/d-passport)
 
 ## Projects in production
 

--- a/src/server/site.js
+++ b/src/server/site.js
@@ -58,7 +58,7 @@ expressApp.get('/docs/derby-0.6/?*', function(req, res, next) {
 });
 
 expressApp.get('/docs', function(req, res, next) {
-  res.redirect('https://derbyjs.github.io/derby/');
+  res.redirect(301, 'https://derbyjs.github.io/derby/');
 });
 
 var outlineData = require('./outline').generate(app);

--- a/src/server/site.js
+++ b/src/server/site.js
@@ -58,7 +58,7 @@ expressApp.get('/docs/derby-0.6/?*', function(req, res, next) {
 });
 
 expressApp.get('/docs', function(req, res, next) {
-  res.redirect('/docs/derby-0.10');
+  res.redirect('https://derbyjs.github.io/derby/');
 });
 
 var outlineData = require('./outline').generate(app);

--- a/styles/app/docs.styl
+++ b/styles/app/docs.styl
@@ -99,6 +99,10 @@
   .docs-thumbs img
     display: inline-block;
 
+  .warning
+    background-color: derbyTealLighter
+    padding: 20px
+
 
 code
   //color: derbyBlack

--- a/views/app/home.html
+++ b/views/app/home.html
@@ -48,7 +48,7 @@
           <div class="row">
             <h2>Community</h2>
             <p>
-              <a href="/resources#community">Connect</a> with people using and developing DerbyJS! Ask questions and show off what you are building on the <a href="https://groups.google.com/group/derbyjs" target="_blank">mailing list</a>, <a href="https://stackoverflow.com/questions/tagged/derbyjs" target="_blank">StackOverflow</a>, <a href="https://github.com/derbyjs" target="_blank">GitHub</a> and more!
+              <a href="/resources#community">Connect</a> with people using and developing DerbyJS!
             </p>
           </div>
 

--- a/views/app/index.html
+++ b/views/app/index.html
@@ -23,11 +23,19 @@
           <view is="{{$render.ns}}:sidebar" optional></view>
         </div>
         <div class="col-md-9 main">
+          {{if String.prototype.startsWith.call($render.ns, 'docs:')}}
+            <div class="warning">
+              <b>⚠️ Deprecated</b> &mdash; These docs are no longer updated.<br>
+              Visit the new docs at <a href="https://derbyjs.github.io/derby/" style="font-weight: bold;">derbyjs.github.io/derby/</a> instead!
+            </div>
+          {{/if}}
           <view is="{{$render.ns}}"></view>
           {{if _page.links[$render.ns]}}
             <a class="btn btn-outline btn-lg next" href="{{this}}">Next&nbsp; &#10132;</a>
           {{/if}}
-          <a class="edit-on-github" href="{{gitHubEditLink($render.url)}}">Edit on GitHub</a>
+          {{if !String.prototype.startsWith.call($render.ns, 'docs:')}}
+            <a class="edit-on-github" href="{{gitHubEditLink($render.url)}}">Edit on GitHub</a>
+          {{/if}}
         <view is="main-footer"></view>
         </div>
     </div>
@@ -53,14 +61,10 @@
       <nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
         <ul class="nav navbar-nav">
           <view is="nav-link" href="/started">Get started</view>
-          <view is="nav-link" href="/docs/derby-0.10">Docs</view>
+          <view is="nav-link" href="https://derbyjs.github.io/derby/">Docs</view>
           <view is="nav-link" href="/resources">Resources</view>
         </ul>
       </nav>
-      <div class="navbar-search-container">
-        <script async src="https://cse.google.com/cse.js?cx=011470309218197930356:xg9bmk4xhsg"></script>
-        <div class="gcse-searchbox-only"></div>
-      </div>
     </div>
   </div>
 
@@ -83,10 +87,6 @@
         </ul>
       </div>
       <ul class="bs-docs-footer-links muted">
-        <li><a href="https://groups.google.com/forum/#!forum/derbyjs" target="_blank">Google Group</a></li>
-        <li>&middot;</li>
-        <li><a href="https://gitter.im/derbyjs/derby" target="_blank">Gitter chat</a></li>
-        <li>&middot;</li>
         <li><a href="https://github.com/derbyjs/derby" target="_blank">GitHub</a></li>
         <li>&middot;</li>
         <li><a href="https://github.com/derbyjs/derby/issues?state=open" target="_blank">Issues</a></li>


### PR DESCRIPTION
- Update the Docs header link to point to new GitHub Pages hosted doc site at https://derbyjs.github.io/derby/
- Add deprecation banner on all doc pages inside this repo, also linking to new doc site
- Remove obsolete community links
- Remove search box, since new doc site has a better search

----

Screenshot of the deprecation message:
<img width="996" alt="Screenshot 2024-05-30 at 3 45 55 PM" src="https://github.com/derbyjs/derby-site/assets/6915076/30ce61ec-fe6d-4f13-8378-93ca194934f6">
